### PR TITLE
Update docsRepo link to new getdoks.org repo

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -43,7 +43,7 @@ alert = false
 alertText = "Like Doks? <a class=\"alert-link\" href=\"https://github.com/h-enk/doks/stargazers\">Star on GitHub</a>!</a>"
 
 # Edit Page
-docsRepo = "https://github.com/h-enk/doks"
+docsRepo = "https://github.com/h-enk/getdoks.org"
 editPage = true
 
 [options]


### PR DESCRIPTION
The current docsRepo link goes to the old repo url which means the edit button doesn't work correctly. This fixes it to redirect to the correct repo when clicking the edit button