### PR TITLE
Fixing broken links, fixing typos

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -43,7 +43,7 @@ alert = false
 alertText = "Like Doks? <a class=\"alert-link\" href=\"https://github.com/h-enk/doks/stargazers\">Star on GitHub</a>!</a>"
 
 # Edit Page
-docsRepo = "https://github.com/h-enk/doks"
+docsRepo = "https://github.com/h-enk/getdoks.org"
 editPage = true
 
 [options]

--- a/content/docs/contributing/how-to-contribute.md
+++ b/content/docs/contributing/how-to-contribute.md
@@ -13,7 +13,7 @@ weight: 510
 toc: true
 ---
 
-{{< alert icon="👉" text="Make sure to read the <a href=\"/docs/contribute/code-of-conduct/\">Code of Conduct</a>" >}}
+{{< alert icon="👉" text="Make sure to read the <a href=\"/docs/contributing/code-of-conduct/\">Code of Conduct</a>" >}}
 
 ## Contribute to Doks
 

--- a/content/docs/recipes/deployment/index.md
+++ b/content/docs/recipes/deployment/index.md
@@ -58,14 +58,14 @@ jobs:
           publish_dir: ./public
 ```
 
-2. Click on the __Actions__ tab of your GitHub repo and wait for the action to finish succesfully (after approximately 30 seconds).
+2. Click on the __Actions__ tab of your GitHub repo and wait for the action to finish successfully (after approximately 30 seconds).
 
 {{< img-simple src="select-branch.png" alt="Select branch" class="border-0" >}}
 
-3. Go to the __Sections__ tab of your GitHub repo and scroll down to the __GitHub Pages__ section. Select branche `gh-pages` and click __Save__.
+3. Go to the __Sections__ tab of your GitHub repo and scroll down to the __GitHub Pages__ section. Select branch `gh-pages` and click __Save__.
 4. Copy the __Your site is published at__ URL and paste it as `baseurl` in `./config/production/config.toml`.
-5. Push the changes to GitHub and wait for the action to finish succesfully (after approximately 30 seconds).
-6. That's it. After a minute or so, you site is avaliable at the __Your site is published at__ URL.
+5. Push the changes to GitHub and wait for the action to finish successfully (after approximately 30 seconds).
+6. That's it. After a minute or so, you site is available at the __Your site is published at__ URL.
 
 Now, after every push to the master branch, your site will be updated — automatically.
 


### PR DESCRIPTION
This PR fixes some typos and broken links.
Currently, all links `Edit this page on GitHub` on all pages are broken since `docsRepo` in params.toml is incorrect. This is corrected too (I just saw that this was adressed in #103, too).

Looking forward to see this project growing. Especially I'm awaiting the [multilingual feature](https://github.com/h-enk/doks/issues/114), since not having this feature yet restricts the use of this theme for me. 