### PR TITLE
fix(newsletter): disable subscribe button onsubmit

### DIFF
--- a/layouts/partials/sidebar/newsletter.html
+++ b/layouts/partials/sidebar/newsletter.html
@@ -4,14 +4,14 @@
 
     <h3 class="h4 card-title">Stay in the loop</h3>
     <p class="card-text">Subscribe to the Doks newsletter and get occasional updates.</p>
-    <form class="row gx-2 gy-3 email-form" name="newsletter" method="post" netlify-honeypot="name" data-netlify="true">
+    <form class="row gx-2 gy-3 email-form" name="newsletter" method="post" netlify-honeypot="name" data-netlify="true" onsubmit="subscribeButton.disabled = true">
       <div class="col-md-12">
         <input name="name" type="text" class="form-control visually-hidden" placeholder="your name" aria-label="Name">
         <input name="email" type="email" class="form-control" placeholder="your@email.com" aria-label="Email address" required>
         <input name="page" type="hidden" value="{{ .Page.Permalink }}">
       </div>
       <div class="col-md-4">
-        <button type="submit" class="btn btn-primary w-100" aria-label="Subscribe">Subscribe</button>
+        <button id="subscribeButton" type="submit" class="btn btn-primary w-100" aria-label="Subscribe">Subscribe</button>
       </div>
     </form>
 


### PR DESCRIPTION
## Summary

Disable subscribe button on click to prevent multiple submissions

## Basic example

https://sideofburritos.com - I added the newsletter form to my homepage with this change.

screenshot - https://imgur.com/a/pbGESIo

## Motivation

By the time the function completes submission to the API, the user could click the subscribe button 4-5 times generating multiple, duplicate, POST requests.

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`